### PR TITLE
Added von Neumann entropy feature by optimizing measurement basis

### DIFF
--- a/docs/source/cost/entropic_quantities.rst
+++ b/docs/source/cost/entropic_quantities.rst
@@ -3,6 +3,8 @@ Entropic Quantities
 
 .. currentmodule:: qnetvo
 
+.. autofunction:: shannon_entropy_cost_fn
+
 .. autofunction:: mutual_info_cost_fn
 
 

--- a/src/qnetvo/cost/mutual_info.py
+++ b/src/qnetvo/cost/mutual_info.py
@@ -99,3 +99,45 @@ def mutual_info_cost_fn(
         return -(mutual_info)
 
     return cost_fn
+
+
+def von_neumann_entropy(ansatz, **qnode_kwargs):
+    """Constructs an function that finds the von Neumann entropy through optimization
+
+        The von Neumann entropy quantifies how mixed a quantum state :math:'rho' is.
+        It is defined by the expression:
+        .. math::
+
+                S(\\rho) = Tr(\\rho \\log(\\rho))
+
+        where the :math:'\\log' operator here refers to the matrix logarithm. For any given state,
+        if we measure in its eigenbasis, the Shannon entropy is minimized and coincides with the
+        von Neumann entropy. As the measurement basis deviates from the eigenbases, the measurement
+        outcomes becomes noisier and Shannon entropy diverge from the von Neumann entropy. Thus,
+        the von Neumann entropy will be found by numerically finding the eigenbasis via minimizing
+        the Shannon entropy.
+
+        :param ansatz: The ansatz circuit on which the von Neumann entropy is evalutated.
+        :type ansatz: NetworkAnsatz
+
+        :param qnode_kwargs: Keyword arguments passed to the execute qnodes.
+        :type qnode_kwargs: dictionary
+
+        :returns: A cost function ``von_neumann_entropy(scenario_settings)`` parameterized by
+                  the ansatz-specific scenario settings.
+        :rtype: Function
+        """
+    num_prep_nodes = len(ansatz.prepare_nodes)
+    num_meas_nodes = len(ansatz.measure_nodes)
+
+    probs_qnode = joint_probs_qnode(ansatz, **qnode_kwargs)
+
+    def cost_fn(scenario_settings):
+        settings = ansatz.qnode_settings(scenario_settings, [0] * num_prep_nodes, [0] * num_meas_nodes)
+        py_vec = probs_qnode(settings)
+
+        Hy = shannon_entropy(py_vec)
+
+        return Hy
+
+    return cost_fn

--- a/src/qnetvo/cost/mutual_info.py
+++ b/src/qnetvo/cost/mutual_info.py
@@ -85,9 +85,7 @@ def mutual_info_cost_fn(
                 prep_input_vals = [0] * num_prep_nodes
                 meas_input_vals = input_id_set[0:num_meas_nodes]
 
-            settings = ansatz.qnode_settings(
-                scenario_settings, prep_input_vals, meas_input_vals
-            )
+            settings = ansatz.qnode_settings(scenario_settings, prep_input_vals, meas_input_vals)
 
             p_mac = postmap @ probs_qnode(settings)
 

--- a/src/qnetvo/cost/mutual_info.py
+++ b/src/qnetvo/cost/mutual_info.py
@@ -110,7 +110,7 @@ def shannon_entropy_cost_fn(ansatz, **qnode_kwargs):
 
     .. math::
 
-            H(X) = \\sum_{x} P(x) log_{2} P(x)
+            H(X) = \\sum_{x} P(x) \\log_{2} P(x)
 
     In the case of a quantum network, the Shannon entropy is defined on the measurement outcome
     of the network ansatz.

--- a/src/qnetvo/cost/mutual_info.py
+++ b/src/qnetvo/cost/mutual_info.py
@@ -107,6 +107,7 @@ def shannon_entropy_cost_fn(ansatz, **qnode_kwargs):
     The Shannon entropy characterizes the amount of randomness, or similarly, the amount of
     information is present in a random variable. Formally, let :math:'X' be a discrete random
     variable, then the Shannon entropy is defined by the expression:
+
     .. math::
 
             H(X) = \\sum_{x} P(x) log_{2} P(x)

--- a/src/qnetvo/cost/mutual_info.py
+++ b/src/qnetvo/cost/mutual_info.py
@@ -85,7 +85,9 @@ def mutual_info_cost_fn(
                 prep_input_vals = [0] * num_prep_nodes
                 meas_input_vals = input_id_set[0:num_meas_nodes]
 
-            settings = ansatz.qnode_settings(scenario_settings, prep_input_vals, meas_input_vals)
+            settings = ansatz.qnode_settings(
+                scenario_settings, prep_input_vals, meas_input_vals
+            )
 
             p_mac = postmap @ probs_qnode(settings)
 

--- a/test/cost/mutual_info_test.py
+++ b/test/cost/mutual_info_test.py
@@ -85,3 +85,43 @@ class TestMutualInfoOptimimzation:
         )
 
         assert np.isclose(opt_dict["scores"][-1], match, atol=0.0005)
+
+
+class TestVonNeumannEntropy:
+
+    def test_von_neumann_entropy_pure_state(self):
+        prep_node = [qnet.PrepareNode(1, [0, 1], qnet.ghz_state, 0)]
+        meas_node = [
+            qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)
+        ]
+
+        ansatz = qnet.NetworkAnsatz(prep_node, meas_node)
+        von_neumann_entropy = qnet.von_neumann_entropy(ansatz)
+
+        settings = ansatz.rand_scenario_settings()
+        opt_dict = qnet.gradient_descent(
+            von_neumann_entropy, settings, step_size=0.05, sample_width=5, num_steps=100
+        )
+
+        assert np.isclose(opt_dict["scores"][-1], 0, atol=0.0005)
+
+    def test_von_neumann_entropy_mixed_state(self):
+        prep_node = [qnet.PrepareNode(1, [0, 1], qnet.ghz_state, 0)]
+        meas_node = [
+            qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)
+        ]
+        gamma = 0.1
+        noise_node = [
+            qnet.NoiseNode([0], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)),
+            qnet.NoiseNode([1], lambda settings, wires: qml.DepolarizingChannel(gamma, wires))
+        ]
+
+        ansatz = qnet.NetworkAnsatz(prep_node, meas_node, noise_node)
+        von_neumann_entropy = qnet.von_neumann_entropy(ansatz)
+
+        settings = ansatz.rand_scenario_settings()
+        opt_dict = qnet.gradient_descent(
+            von_neumann_entropy, settings, step_size=0.05, sample_width=5, num_steps=100
+        )
+
+        assert abs(opt_dict["scores"][-1]) > 0.5

--- a/test/cost/mutual_info_test.py
+++ b/test/cost/mutual_info_test.py
@@ -92,7 +92,7 @@ class TestShannonEntropy:
         np.random.seed(123)
 
         prep_node = [qnet.PrepareNode(1, [0, 1], qnet.ghz_state, 0)]
-        meas_node = [qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)]
+        meas_node = [qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4**2 - 1)]
 
         ansatz = qnet.NetworkAnsatz(prep_node, meas_node)
         shannon_entropy = qnet.shannon_entropy_cost_fn(ansatz)
@@ -108,15 +108,11 @@ class TestShannonEntropy:
         np.random.seed(123)
 
         prep_node = [qnet.PrepareNode(1, [0, 1], qnet.ghz_state, 0)]
-        meas_node = [qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)]
+        meas_node = [qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4**2 - 1)]
         gamma = 0.04
         noise_node = [
-            qnet.NoiseNode(
-                [0], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)
-            ),
-            qnet.NoiseNode(
-                [1], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)
-            ),
+            qnet.NoiseNode([0], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)),
+            qnet.NoiseNode([1], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)),
         ]
 
         ansatz = qnet.NetworkAnsatz(prep_node, meas_node, noise_node)

--- a/test/cost/mutual_info_test.py
+++ b/test/cost/mutual_info_test.py
@@ -111,8 +111,12 @@ class TestShannonEntropy:
         meas_node = [qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)]
         gamma = 0.04
         noise_node = [
-            qnet.NoiseNode([0], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)),
-            qnet.NoiseNode([1], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)),
+            qnet.NoiseNode(
+                [0], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)
+            ),
+            qnet.NoiseNode(
+                [1], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)
+            ),
         ]
 
         ansatz = qnet.NetworkAnsatz(prep_node, meas_node, noise_node)

--- a/test/cost/mutual_info_test.py
+++ b/test/cost/mutual_info_test.py
@@ -87,41 +87,40 @@ class TestMutualInfoOptimimzation:
         assert np.isclose(opt_dict["scores"][-1], match, atol=0.0005)
 
 
-class TestVonNeumannEntropy:
+class TestShannonEntropy:
+    def test_shannon_entropy_pure_state(self):
+        np.random.seed(123)
 
-    def test_von_neumann_entropy_pure_state(self):
         prep_node = [qnet.PrepareNode(1, [0, 1], qnet.ghz_state, 0)]
-        meas_node = [
-            qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)
-        ]
+        meas_node = [qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)]
 
         ansatz = qnet.NetworkAnsatz(prep_node, meas_node)
-        von_neumann_entropy = qnet.von_neumann_entropy(ansatz)
+        shannon_entropy = qnet.shannon_entropy_cost_fn(ansatz)
 
         settings = ansatz.rand_scenario_settings()
         opt_dict = qnet.gradient_descent(
-            von_neumann_entropy, settings, step_size=0.05, sample_width=5, num_steps=100
+            shannon_entropy, settings, step_size=0.08, sample_width=5, num_steps=30
         )
 
         assert np.isclose(opt_dict["scores"][-1], 0, atol=0.0005)
 
     def test_von_neumann_entropy_mixed_state(self):
+        np.random.seed(123)
+
         prep_node = [qnet.PrepareNode(1, [0, 1], qnet.ghz_state, 0)]
-        meas_node = [
-            qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)
-        ]
-        gamma = 0.1
+        meas_node = [qnet.MeasureNode(1, 4, [0, 1], qml.ArbitraryUnitary, 4 ** 2 - 1)]
+        gamma = 0.04
         noise_node = [
             qnet.NoiseNode([0], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)),
-            qnet.NoiseNode([1], lambda settings, wires: qml.DepolarizingChannel(gamma, wires))
+            qnet.NoiseNode([1], lambda settings, wires: qml.DepolarizingChannel(gamma, wires)),
         ]
 
         ansatz = qnet.NetworkAnsatz(prep_node, meas_node, noise_node)
-        von_neumann_entropy = qnet.von_neumann_entropy(ansatz)
+        shannon_entropy = qnet.shannon_entropy_cost_fn(ansatz)
 
         settings = ansatz.rand_scenario_settings()
         opt_dict = qnet.gradient_descent(
-            von_neumann_entropy, settings, step_size=0.05, sample_width=5, num_steps=100
+            shannon_entropy, settings, step_size=0.1, sample_width=5, num_steps=30
         )
 
-        assert abs(opt_dict["scores"][-1]) > 0.5
+        assert np.isclose(opt_dict["scores"][-1], -0.518, atol=0.0005)


### PR DESCRIPTION
Given fixed source and noise nodes, the added feature changes the measurement basis to minimize Shannon entropy of the output collected at measurement nodes. Two tests -- no-noise and under depolarizing noise -- are included, yielding (close to) zero and non-zero von Neumann entropy